### PR TITLE
#24 follow OWASP recommendations to protect shutdown port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a ch
 ## [Unreleased](https://github.com/idealista/tomcat-role/tree/develop)
 
 ### Added
-- *[#21](https://github.com/idealista/tomcat-role/issues/21) Remove folders from webapps* @dortegau
+- *[#24](https://github.com/idealista/tomcat-role/issues/24) Follow OWASP recommendations to protect Shutdown port* @dortegau
+- *[#21](https://github.com/idealista/tomcat-role/issues/21) Remove pre-installed folders from webapps* @dortegau
 
 ## [1.3.1](https://github.com/idealista/tomcat-role/tree/1.3.1)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ tomcat_force_reinstall: false
 
 ## Ports
 tomcat_shutdown_port: 8005
+tomcat_shutdown_command: SHUTDOWN
 
 tomcat_http_connector_port: 8080
 tomcat_http_connector_connection_timeout: 20000

--- a/templates/server.xml.j2
+++ b/templates/server.xml.j2
@@ -19,7 +19,7 @@
      define subcomponents such as "Valves" at this level.
      Documentation at /docs/config/server.html
  -->
-<Server port="{{ tomcat_shutdown_port }}" shutdown="SHUTDOWN">
+<Server port="{{ tomcat_shutdown_port }}" shutdown="{{ tomcat_shutdown_command }}">
   <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
   <!-- Security listener. Documentation at /docs/config/listeners.html
   <Listener className="org.apache.catalina.security.SecurityListener" />


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

Adding tomcat_shutdown_command variable to hold the shutdown command word in both default vars file and server.xml template

### Benefits

Shutdown command should be customizable

### Possible Drawbacks

AFAIK there are not possible drawbacks

### Applicable Issues

#24 
