### PR TITLE
Allow the option to pass additional environment vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a changelog](https://github.com/olivierlacan/keep-a-changelog).
 
 ## [Unreleased](https://github.com/idealista/tomcat-role/tree/develop)
+### Changed
+- *[#53](https://github.com/idealista/tomcat-role/issues/53) Allow the option to pass additional environment vars* @sorobon
+- *Tomcat version to 8.5.31* @sorobon
+### Fixed
+- *[#4](https://github.com/idealista/tomcat-role/issues/4) Notify restart handler after new files copied/template* @sorobon
+
 
 ## [1.6.2](https://github.com/idealista/tomcat-role/tree/1.6.2)
 ### Changed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 ## General
 
-tomcat_version: 8.5.29
+tomcat_version: 8.5.31
 
 ## Service options
 
@@ -41,6 +41,10 @@ tomcat_connector_redirect_port: 8443
 tomcat_catalina_opts:
   - -Xms512m
   - -Xmx512m
+
+tomcat_environment_vars:
+  - name: UMASK
+    value: "\"0022\""
 
 ## Tomcat roles
 tomcat_roles:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,5 +1,12 @@
 ---
 
+- name: Tomcat | Delete pre-installed folders in webapps
+  file:
+    path: "{{ tomcat_webapps_path }}/{{ item.key }}/"
+    state: absent
+  with_dict: "{{ tomcat_pre_installed_folders_deployed }}"
+  when: 'not item.value.deployed'
+
 - name: Tomcat | Copy tomcat config
   template:
     src: "{{ item.src }}"
@@ -25,6 +32,7 @@
     - "{{ tomcat_extra_conf_path }}/"
     - "{{ tomcat_extra_conf_template_path }}/"
   when: item.state == "directory"
+  notify: restart tomcat
 
 - name: Tomcat | Copy extra tomcat config files (provided by playbooks)
   copy:
@@ -36,6 +44,7 @@
   with_filetree:
     - "{{ tomcat_extra_conf_path }}/"
   when: item.state == "file"
+  notify: restart tomcat
 
 - name: Tomcat | Copy extra tomcat config templates (provided by playbooks)
   template:
@@ -47,3 +56,4 @@
   with_filetree:
     - "{{ tomcat_extra_conf_template_path }}/"
   when: item.state == "file"
+  notify: restart tomcat

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -49,10 +49,3 @@
     dest: /lib/systemd/system/tomcat.service
     mode: 0644
   notify: restart tomcat
-
-- name: Tomcat | Delete pre-installed folders in webapps
-  file:
-    path: "{{ tomcat_webapps_path }}/{{ item.key }}/"
-    state: absent
-  with_dict: "{{ tomcat_pre_installed_folders_deployed }}"
-  when: 'not item.value.deployed'

--- a/templates/setenv.sh.j2
+++ b/templates/setenv.sh.j2
@@ -1,5 +1,12 @@
 #! /bin/sh
 
+{% if tomcat_environment_vars is defined %}
+{% for env_var in tomcat_environment_vars %}
+export {{ env_var.name }}={{ env_var.value }}
+{% endfor %}
+{% endif %}
+
+
 {% for option in tomcat_catalina_opts %}
 export CATALINA_OPTS="$CATALINA_OPTS {{ option }}"
 {% endfor %}


### PR DESCRIPTION
### Description

Need to add the option to add environment variables as the same way we can configure the catalina_opts variable.


**Expected behavior:** Add a variable in the configuration (main.yml or whatever) and configure the tomcat instance to use it.

In config.yml, lines 16 and 26, if there's any change, they don't notify the restart handler. This should be changed, as any new configuration should restart (or maybe just reload) the server.

Changed the default tomcat version to 8.5.31